### PR TITLE
fix: remove reactions

### DIFF
--- a/src/events/meow.ts
+++ b/src/events/meow.ts
@@ -9,7 +9,7 @@ const meows = [
     },
     {
         regex: /(m+e+e+p)/,
-        reactions: ['<:illness:1185052052020281416>', '<:imo:1185052054054522910>']
+        reactions: []
     }
 ];
 


### PR DESCRIPTION
Remove erroneous reactions left due to piggybacking off of the existing meow reaction handler.